### PR TITLE
Add HF Base Model Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,6 @@
 .vscode
 Dockerfile
 memory
-model
 sources
-*.md
+model/*/*
+!model/*/q4_0.bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .chainlit
 .env
+.venv
 .vscode/
 **__pycache__**
 chainlit.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ WORKDIR $HOME/app
 
 COPY --chown=user . $HOME/app
 
-RUN ollama serve & sleep 5 && ollama create volo -f ./Modelfile
+RUN ollama serve & \
+    sleep 5 && \
+    ollama create volo -f ./Modelfile
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 

--- a/Modelfile
+++ b/Modelfile
@@ -1,12 +1,22 @@
-FROM neural-chat:latest
+FROM neural-chat
+# FROM ./model/<modelname>/q4_0.bin
 
 PARAMETER repeat_penalty 1.3
 PARAMETER temperature 0.4
 PARAMETER top_k 20
 PARAMETER top_p 0.65
 
+TEMPLATE """### System:
+{{ .System }}
+
+### User:
+{{ .Prompt }}
+
+### Assistant:
+"""
+
 SYSTEM """
-### System: Given the following extracted parts of a long document and a question, create a final answer with references ("SOURCES"). 
+Given the following extracted parts of a long document and a question, create a final answer with references ("SOURCES"). 
 If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 ALWAYS return a "SOURCES" part in your answer.
 ---

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ colorTo: gray
 license: mit
 pinned: true
 sdk: docker
-startup_duration_timeout: 6h
 title: Multi Mediawiki RAG
 ---
 --->
@@ -76,6 +75,9 @@ multi-mediawiki-rag
 ├── memory
 │   └── cache.db # Chat Cache
 ├── model
+│   ├── <modelname>
+│   │   ├── q4_0.bin
+│   │   └── *
 │   └── sentence-transformers_all-mpnet-base-v2
 │       └── *
 ├── requirements.txt
@@ -104,13 +106,22 @@ These instructions will get you a copy of the project up and running on your loc
 These steps assume you are using a modern Linux OS like Ubuntu with Python 3.
 
 1. Download a mediawiki's XML dump by browsing to `/wiki/Special:Statistics`.
-2. Install [Ollama](https://github.com/jmorganca/ollama) with `curl https://ollama.ai/install.sh | sh`.
-3. Edit [`config.yaml`](config.yaml) with the location of your XML mediawiki data and other configuration data.
-4. Install python requirements:
+2. (Optional)
+   1. Install [Git LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage?platform=linux)
+   2. download your model of choice from [Huggingface](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) with `git clone https://huggingface.co/<org>/<modelname> model/<modelname>`.
+   3. Modify [Modelfile](Modelfile) to point to the same directory as your modelname of choice.
+3. Install [Ollama](https://github.com/jmorganca/ollama) with `curl https://ollama.ai/install.sh | sh`.
+4. Edit [`config.yaml`](config.yaml) with the location of your XML mediawiki data you downloaded in step 1 and other configuration data.
+5. Edit [`Modelfile`](Modelfile) with the location of the model you downloaded in step 2.
+6. Create a directory to store chat history with `mkdir memory`.
+7. Install python requirements:
 
 ```bash
+pip install -U pip setuptools wheel
 pip install -r requirements.txt
 ```
+
+>**Note:** To properly install Chroma, you might need to install a newer version of [sqlite3](https://www.sqlite.org/download.html).
 
 ### Create Custom LLM
 
@@ -118,7 +129,11 @@ After installing Ollama we can use a [Modelfile](https://github.com/jmorganca/ol
 
 ```bash
 ollama create volo -f ./Modelfile
+# Test the model
+ollama run volo "Hello World"
 ```
+
+>**Note:** If your model of choice is not in `GGUF` format, you can convert it with docker via `docker run --rm -v $PWD/model/<modelname>:/model ollama/quantize -q q4_0 /model`.
 
 ### Create Vector Database
 

--- a/main.py
+++ b/main.py
@@ -169,4 +169,5 @@ if __name__ == "__main__":
 
     res = chain(wiki.prompt)
     answer = res["answer"]
+    print(answer)
     print([source_doc.page_content for source_doc in res["source_documents"]])


### PR DESCRIPTION
## Describe your changes
- Add a `TEMPLATE` section to the modelfile since huggingface models do not share the same `TEMPLATE` as ollama models.
- Add documentation for how to set up and download models to be created this way.
- Make base model support optional.
- Ensure dockerfile picks up int4 quantized models.

## Issue ticket number and link
#3 

## How you have validated your changes
Locally via two different models quantized to int4 and hosted with Chainlit. These changes were tested on a different machine with a different setup to my previous commits.